### PR TITLE
Fix compile.

### DIFF
--- a/Shazzam/Controls/AdjustableColor.xaml.cs
+++ b/Shazzam/Controls/AdjustableColor.xaml.cs
@@ -7,7 +7,7 @@
     using System.Windows.Input;
     using System.Windows.Media;
     using System.Windows.Media.Animation;
-    using Microsoft.Windows.Controls;
+    using Xceed.Wpf.Toolkit;
 
     public partial class AdjustableColor : UserControl
     {


### PR DESCRIPTION
After update WPFToolkit.Extended from 1.5.x to 4.5.1, the namespace of `ColorPicker` class will bring from `Microsoft.Windows.Controls` to `Xceed.Wpf.Toolkit`.